### PR TITLE
Issue 77: Fix syntax highlighting

### DIFF
--- a/src/tracks/contract-first/customizing-openapi-generator-templates.md
+++ b/src/tracks/contract-first/customizing-openapi-generator-templates.md
@@ -144,7 +144,7 @@ git checkout openapi_templating_jpa_setup
     - `modules/openapi-generator/src/main/resources/JavaSpring
   - This folder contains all of the template files used to generate the spring code from the previous application. It is worth taking some time to look at some of the different templates
     - Note the `library` folder that contain the 3 different libraries you can set. We chose spring boot when creating our application
-  - Inside the `tempalte` folder of our application you will find `pojo.mustache`. This should match up with the `pojo.mustache` in the openapi-generator repository. with some added TODO tags
+  - Inside the `template` folder of our application you will find `pojo.mustache`. This should match up with the `pojo.mustache` in the openapi-generator repository. with some added TODO tags
 3. Update `pom.xml` to use templates folder
   - Add `<templateDirectory>${project.basedir}/templates</templateDirectory>` to the configuration of the `opeanpi-generator-maven-plugin`
     <sub>Note: be sure to add this to the configuration *NOT* the configOptions</sub>
@@ -152,7 +152,7 @@ git checkout openapi_templating_jpa_setup
   - In order to use custom properties inside of templates are stored in 'vendorExtensions' and should begin with `x-`. You can read more about that [here](https://swagger.io/docs/specification/openapi-extensions/)
     - Add class annotations
       - Add the following directly above `@ApiModel` annotation (~line 4)
-        ```mustache
+        ```handlebars
         {{#vendorExtensions.x-java-class-annotation}}
         {{{.}}}
         {{/vendorExtensions.x-java-class-annotation}}
@@ -168,7 +168,7 @@ git checkout openapi_templating_jpa_setup
     - Add field annotations
       ::: v-pre
       - Add the following directly inside the `{{#vars}}` loop, above `{{#isEnum}}` (~line 13)
-        ```mustache
+        ```handlebars
           {{#vendorExtensions.x-java-field-annotation}}
           {{{.}}}
           {{/vendorExtensions.x-java-field-annotation}}

--- a/src/tracks/contract-first/openapi-generator.md
+++ b/src/tracks/contract-first/openapi-generator.md
@@ -76,7 +76,7 @@ If you completed the previous lab you should be able to follow the lab by downlo
         -p java8=true
    ```
    **Note:** We are using the *sourceFolder* parameter to change where OpenAPI Generator places the generated Java code. By placing it in `src/main/gen` instead of `src/main/java` we are indicating that this code is created by the generator and should be treated as immutable.
-   
+
    - Open the code in an IDE of your choice and take some time to look around the code. Take note that we are currently generating all the files related to the application inside of the `src/main/gen` folder.
 2. Add the `src/main/gen` to your source directories:
    - Add the following plugin to your `pom.xml`:
@@ -125,12 +125,12 @@ If you completed the previous lab you should be able to follow the lab by downlo
          response.setDate(OffsetDateTime.now().plusDays(1));
          return ResponseEntity.ok(response);
      }
-     ``` 
+     ```
      **Note:** we are returning a `200` response code. This is compliant with our OAS specification. Currently we don't have any validation on which response code we are returning but it is best practice to follow what is specified by your OpenAPI document. And in the future we will be looking at [Schemathesis](https://github.com/schemathesis/schemathesis) which will run test to validate that all expected response codes are returned.
    - Prevent the regeneration of the `TodosApisController.java`:
       - In order to prevent files that you add to your `src/main/java` from being recreated in `src/main/gen` they need to be added to your `.openapi-generator-ignore` file.
       - Add the following lines to prevent any `*Controller.java` files from being added, as well as preventing us from overriding our `pom.xml`:
-      ```regex
+      ```bash
       **/*Controller.java
       pom.xml
       ```
@@ -176,7 +176,7 @@ If you completed the previous lab you should be able to follow the lab by downlo
         </plugin>
         ```
      **Warning:** If you did not add `pom.xml` to your `.openapi-generator-ignore` file the next build will override your `pom.xml` and you will need to add back the previous plugin.
-     
+
      - Explore the new OAS file being pulled from GitHub:
         - Note the new `user` schema as well as the new paths associated with the new user object.
      - Validate that `TodosApisController.java` has been deleted from your `src/main/gen` folder and regenerate your files with `mvn generate-sources`.


### PR DESCRIPTION
The syntax highlighting for `mustache` templates and `regex` were not working with the new vitepress implementation, so I had to update the hints.